### PR TITLE
nes.css 확대하면 점선 깨지는 현상 해결한 버전

### DIFF
--- a/packages/client/src/App.css
+++ b/packages/client/src/App.css
@@ -37,7 +37,7 @@
        0 4px 0 0 var(--nes-rounded-border-color);  /* 아래쪽 테두리 */
 }
 
-/* 예: 검은색 테마 컨테이너일 경우 */
+/* 검은색 테마용 기본 라운드 컨테이너 스타일 (.nes-container.is-rounded.is-dark 전체에 적용됨, 필요 시 주석 처리하거나 커스터마이즈 가능) */
 .nes-container.is-rounded.is-dark {
   background-color: #212529; /* 내부 배경 */
   color: #fff; /* 글자색 */


### PR DESCRIPTION
fix: nes.css 설정 파일 위에 container와 button에서 border를 벡터 방식으로 덮어씌우게 해서 해결함 #70

따로 사용하는 inputfield가 있다면 거기서 또 픽셀 깨짐이 일어날 가능성이 있으므로 그때그때 수정하면 됨
이제 확대해도 안 깨집니다
<img width="2277" height="1559" alt="image" src="https://github.com/user-attachments/assets/a786bbe5-3218-490f-830f-91ddc2ae030a" />


