### PR TITLE
닉네임 창에서 게임 중인 경우 접속 못한다고 화면에 그리기 *서버쪽 일부 보강됨 #369

### DIFF
--- a/packages/client/src/components/LandingPage.tsx
+++ b/packages/client/src/components/LandingPage.tsx
@@ -1,7 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import 'nes.css/css/nes.min.css';
 import '../assets/fonts/Font.css';
 import './LandingPage.css';
+import { useGameStore } from '../store/gameStore';
 
 const MAX_NICKNAME_LENGTH = 8;
 const TOOLTIP_DURATION = 2000;
@@ -14,6 +15,19 @@ function LandingPage({ onStart }: LandingPageProps) {
   const [nickname, setNickname] = useState('');
   const [showTooltip, setShowTooltip] = useState(false);
   const [showLengthTooltip, setShowLengthTooltip] = useState(false);
+
+  const connectionError = useGameStore((s) => s.connectionError);
+  const setConnectionError = useGameStore((s) => s.setConnectionError);
+
+  // 접속 에러 메시지 자동 숨김 (2초 후)
+  useEffect(() => {
+    if (connectionError) {
+      const timer = setTimeout(() => {
+        setConnectionError(null);
+      }, TOOLTIP_DURATION);
+      return () => clearTimeout(timer);
+    }
+  }, [connectionError, setConnectionError]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,6 +87,19 @@ function LandingPage({ onStart }: LandingPageProps) {
             </button>
             {showTooltip && !nickname.trim() && (
               <div className="tooltip">닉네임을 입력하세요</div>
+            )}
+            {connectionError && (
+              <div
+                className="length-tooltip"
+                style={{
+                  bottom: '100%',
+                  top: 'auto',
+                  marginBottom: '10px',
+                  marginTop: 0,
+                }}
+              >
+                {connectionError.message}
+              </div>
             )}
           </div>
         </form>

--- a/packages/client/src/network/clientHandler.ts
+++ b/packages/client/src/network/clientHandler.ts
@@ -53,9 +53,13 @@ export const handleServerPacket = (packet: ServerPacket) => {
       break;
     }
 
-    case SystemPacketType.SYSTEM_MESSAGE:
+    case SystemPacketType.SYSTEM_MESSAGE: {
       console.log('SYSTEM_MESSAGE packet received:', packet.message);
+      useGameStore.getState().setConnectionError({
+        message: packet.message,
+      });
       break;
+    }
 
     case SystemPacketType.UPDATE_SCORE: {
       const store = useGameStore.getState();

--- a/packages/client/src/network/socket.ts
+++ b/packages/client/src/network/socket.ts
@@ -5,10 +5,16 @@ import { handleServerPacket } from './clientHandler.ts';
 class SocketManager {
   private socket: Socket | null = null;
 
-  connect(url: string) {
+  connect(url: string): void {
     // [중요] 이미 소켓이 생성되어 있고 연결 중이라면 중복 실행 방지
     if (this.socket && this.socket.connected) {
       return;
+    }
+
+    // 기존 소켓이 있지만 연결이 끊어진 경우 정리
+    if (this.socket && !this.socket.connected) {
+      this.socket.removeAllListeners();
+      this.socket = null;
     }
 
     this.socket = io(url, {
@@ -26,9 +32,9 @@ class SocketManager {
       handleServerPacket(packet);
     });
 
-    this.socket.on('connect', () =>
-      console.log('[SocketManager] Connected! url:', url),
-    );
+    this.socket.on('connect', () => {
+      console.log('[SocketManager] Connected! url:', url);
+    });
     this.socket.on('disconnect', (reason) =>
       console.log('[SocketManager] Disconnected! reason:', reason, 'url:', url),
     );

--- a/packages/client/src/store/gameStore.ts
+++ b/packages/client/src/store/gameStore.ts
@@ -83,6 +83,10 @@ interface GameState {
 
   // 게임 상태 초기화
   resetGameState: () => void;
+
+  // 접속 에러 메시지 (게임 진행 중 접속 시도 등)
+  connectionError: { message: string } | null;
+  setConnectionError: (err: { message: string } | null) => void;
 }
 
 export const useGameStore = create<GameState>()(
@@ -106,6 +110,7 @@ export const useGameStore = create<GameState>()(
     otherPlayerDrags: new Map<number, DragAreaData>(),
     gameResults: null,
     gameSessionId: 0,
+    connectionError: null,
 
     // 기존 액션
     setCount: (newCount: number) => set({ count: newCount }),
@@ -157,6 +162,7 @@ export const useGameStore = create<GameState>()(
         otherPlayerDrags: new Map<number, DragAreaData>(),
         gameResults: null,
       }),
+    setConnectionError: (err) => set({ connectionError: err }),
   })),
 );
 


### PR DESCRIPTION
기존에는 현재 게임중이라 접속할 수 없다고 메시지만 있었는데, 진행 중일때(사과게임 플레이)와 종료되지 않았을때(결과창 보고있을떄) 역시 접속 못하게 차단함 (기존에는 결과창 보고있을 때 누르면 응답이 없었음)
또한 처음 툴팁이 뜨고 또 누르면 버튼 응답이 없는 문제가 소켓 연결 끊어짐이라 이를 수정함
패킷.ts에 현재 게임 상태에 대한 것을 추가함(GAME_IN_PROGRESS, ROOM_FULL 등)
