### PR TITLE
fix:  게임 결과창에서 비방장이 리플레이 버튼과 로비 버튼에 커서 올릴 때 나오는 툴팁 크기가 너무 작음. #400

### DIFF
--- a/packages/client/src/game/utils/game-result/BaseRankedResult.tsx
+++ b/packages/client/src/game/utils/game-result/BaseRankedResult.tsx
@@ -197,14 +197,14 @@ class ResultStyleBuilder {
   public toolTipBox(): React.CSSProperties {
     return {
       position: 'absolute',
-      bottom: `calc(100% + ${this.px(10)})`,
+      bottom: `calc(100% + ${this.px(16)})`,
       left: '50%',
       transform: 'translateX(-50%)',
-      padding: `${this.px(8)} ${this.px(16)}`,
+      padding: `${this.px(12)} ${this.px(24)}`,
       backgroundColor: '#e76e55',
       color: 'white',
       borderRadius: this.px(4),
-      fontSize: this.px(14),
+      fontSize: this.px(24),
       whiteSpace: 'nowrap',
       zIndex: 1000,
       pointerEvents: 'none',
@@ -217,7 +217,7 @@ class ResultStyleBuilder {
       top: '100%',
       left: '50%',
       transform: 'translateX(-50%)',
-      border: `${this.px(6)} solid transparent`,
+      border: `${this.px(10)} solid transparent`,
       borderTopColor: '#e76e55',
     };
   }


### PR DESCRIPTION
결과창 툴팁만 크기 조절함