### PR TITLE
직접 입력 패킷 스패밍 문제 #440

### DIFF
--- a/packages/client/src/components/Lobby.tsx
+++ b/packages/client/src/components/Lobby.tsx
@@ -321,13 +321,18 @@ function Lobby({ players, onGameStart }: LobbyProps) {
       // maxNumber → appleRange 역변환
       const appleRange: '1-9' | '1-5' = cfg.maxNumber === 5 ? '1-5' : '1-9';
 
+      // 입력 중이면 timeLimit은 덮어쓰지 않음
+      const isEditingAppleTime =
+        localTimeInput['apple'] !== undefined &&
+        localTimeInput['apple'] !== '';
+
       setTimeout(() => {
         setGameSettings((prev) => ({
           ...prev,
           apple: {
             ...prev.apple,
             mapSize,
-            timeLimit: cfg.totalTime,
+            timeLimit: isEditingAppleTime ? prev.apple.timeLimit : cfg.totalTime,
             appleRange,
             includeZero: cfg.includeZero,
           },


### PR DESCRIPTION
## feat: 직접 입력 최종 확정 되면 그때 보내기 [#443](https://github.com/kakao-try-catch/main-game/issues/443)
Lobby.tsx 파일에서:

localTimeInput 상태 추가 (라인 79): 직접 입력 중인 값을 로컬에서 관리

commitTimeLimit 함수 추가 (라인 137-152): blur/Enter 시에만 유효성 검사 후 패킷 전송

Apple 게임 시간 입력 필드 수정 (라인 480-521):

onChange: 로컬 상태만 업데이트 (패킷 전송 없음)
onFocus: 현재 값으로 로컬 상태 초기화
onBlur/Enter: commitTimeLimit 호출하여 패킷 전송
Minesweeper 시간 입력 필드 수정 (라인 983-1024): 동일한 패턴 적용

이제 스크롤 버튼을 꾹 누르거나 숫자를 입력할 때 매번 패킷이 전송되지 않고, 엔터키를 누르거나 입력 필드에서 포커스를 잃을 때만 패킷이 전송됩니다.



## fix: 사과 게임 시간 직접 입력 상태에서 정상적으로 동작하지 않는 것 고치기 [#441](https://github.com/kakao-try-catch/main-game/issues/441)
Lobby.tsx:305-345 useEffect에서:

localTimeInput['apple']에 값이 있으면 (입력 중이면) 서버 응답으로 timeLimit을 덮어쓰지 않음
다른 설정들 (mapSize, appleRange, includeZero)은 정상적으로 동기화됨
이제 직접 입력 모드에서:

'1'만 적어도 서버 응답(sanitize된 10)으로 덮어써지지 않음
값을 다 지워도 서버 응답이 즉시 적용되지 않음 (blur 시에만 처리됨